### PR TITLE
add transparency to colorpicker callback

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,3 +1,8 @@
+### 12.02.2025
+```diff
++ Added Notification:ChangeTitle, Notification:ChangeDescription
+```
+
 ### 31.01.2025
 ```diff
 + Added AddDropdown as an Addon

--- a/Library.lua
+++ b/Library.lua
@@ -1452,7 +1452,7 @@ do
         local ModeSelectOuter = Library:Create('Frame', {
             BorderColor3 = Color3.new(0, 0, 0);
             Position = UDim2.fromOffset(ToggleLabel.AbsolutePosition.X + ToggleLabel.AbsoluteSize.X + 4, ToggleLabel.AbsolutePosition.Y + 1);
-            Size = UDim2.new(0, 60, 0, 45 + 2);
+            Size = UDim2.new(0, 60, 0, 2);
             Visible = false;
             ZIndex = 14;
             Parent = ScreenGui;
@@ -1610,6 +1610,7 @@ do
                 ZIndex = 16;
                 Parent = ModeSelectInner;
             });
+            ModeSelectOuter.Size = ModeSelectOuter.Size + UDim2.new(0, 0, 0, 17)
 
             function ModeButton:Select()
                 for _, Button in next, ModeButtons do

--- a/Library.lua
+++ b/Library.lua
@@ -764,6 +764,7 @@ function Library:Unload()
         Library:SafeCallback(UnloadCallback)
     end
 
+    getgenv().LinoriaLib = nil
     ScreenGui:Destroy()
 end
 

--- a/Library.lua
+++ b/Library.lua
@@ -4600,14 +4600,142 @@ function Library:Notify(...)
     
     local Side = string.lower(Library.NotifySide);
 
-    if Side == "right" then
-        Library:RightNotify(Data.Description, Data.Time, Data.SoundId);
-    else
-        Library:LeftNotify(Data.Description, Data.Time, Data.SoundId);
+    local XSize, YSize = Library:GetTextBounds(Text, Library.Font, 14);
+    YSize = YSize + 7
+
+    local NotifyOuter = Library:Create('Frame', {
+        BorderColor3 = Color3.new(0, 0, 0);
+        Size = UDim2.new(0, 0, 0, YSize);
+        ClipsDescendants = true;
+        ZIndex = 100;
+        Parent = if Side == "left" then Library.LeftNotificationArea else Library.RightNotificationArea;
+    });
+
+    local NotifyInner = Library:Create('Frame', {
+        BackgroundColor3 = Library.MainColor;
+        BorderColor3 = Library.OutlineColor;
+        BorderMode = Enum.BorderMode.Inset;
+        Size = UDim2.new(1, 0, 1, 0);
+        ZIndex = 101;
+        Parent = NotifyOuter;
+    });
+
+    Library:AddToRegistry(NotifyInner, {
+        BackgroundColor3 = 'MainColor';
+        BorderColor3 = 'OutlineColor';
+    }, true);
+
+    local InnerFrame = Library:Create('Frame', {
+        BackgroundColor3 = Color3.new(1, 1, 1);
+        BorderSizePixel = 0;
+        Position = UDim2.new(0, 1, 0, 1);
+        Size = UDim2.new(1, -2, 1, -2);
+        ZIndex = 102;
+        Parent = NotifyInner;
+    });
+
+    local Gradient = Library:Create('UIGradient', {
+        Color = ColorSequence.new({
+            ColorSequenceKeypoint.new(0, Library:GetDarkerColor(Library.MainColor)),
+            ColorSequenceKeypoint.new(1, Library.MainColor),
+        });
+        Rotation = -90;
+        Parent = InnerFrame;
+    });
+
+    Library:AddToRegistry(Gradient, {
+        Color = function()
+            return ColorSequence.new({
+                ColorSequenceKeypoint.new(0, Library:GetDarkerColor(Library.MainColor)),
+                ColorSequenceKeypoint.new(1, Library.MainColor),
+            });
+        end
+    });
+
+    local NotifyLabel = Library:CreateLabel({
+        AnchorPoint = if Side == "left" then Vector2.new(0, 0) else Vector2.new(1, 0);
+        Position = if Side == "left" then UDim2.new(0, 4, 0, 0) else UDim2.new(1, -4, 0, 0);
+        Size = UDim2.new(1, -4, 1, 0);
+        Text = Text;
+        TextXAlignment = if Side == "left" then Enum.TextXAlignment.Left else Enum.TextXAlignment.Right;
+        TextSize = 14;
+        ZIndex = 103;
+        RichText = true;
+        Parent = InnerFrame;
+    });
+
+    local SideColor = Library:Create('Frame', {
+        AnchorPoint = if Side == "left" then Vector2.new(0, 0) else Vector2.new(1, 0);
+        Position = if Side == "left" then UDim2.new(0, -1, 0, -1) else UDim2.new(1, -1, 0, -1);
+        BackgroundColor3 = Library.AccentColor;
+        BorderSizePixel = 0;
+        Size = UDim2.new(0, 3, 1, 2);
+        ZIndex = 104;
+        Parent = NotifyOuter;
+    });
+
+    function Data:Resize()
+        XSize, YSize = Library:GetTextBounds(Data.Description, Library.Font, 14);
+        YSize = YSize + 7
+    
+		NotifyOuter.Size = UDim2.new(0, 0, 0, YSize);
+	end
+
+	function Data:ChangeTitle(NewText)
+		if Title then
+            NewText = tostring(NewText)
+
+            Data.Description = (if NewText == "" then "" else "[" .. NewText .. "] ") .. tostring(Info.Description)
+			NotifyLabel.Text = Data.Description;
+
+			Data:Resize();
+		end
+	end
+
+	function Data:ChangeDescription(NewText)
+		if Desc then
+			Data.Description = tostring(NewText);
+			NotifyLabel.Text = Data.Description;
+            
+			Data:Resize();
+		end
+	end
+
+	Data:Resize();
+
+    Library:AddToRegistry(SideColor, {
+        BackgroundColor3 = 'AccentColor';
+    }, true);
+
+    if SoundId then
+        Library:Create('Sound', {
+            SoundId = "rbxassetid://" .. tostring(SoundId):gsub("rbxassetid://", "");
+            Volume = 3;
+            PlayOnRemove = true;
+            Parent = game:GetService("SoundService");
+        }):Destroy();
     end
+
+    pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, XSize * DPIScale + 8 + 4, 0, YSize), 'Out', 'Quad', 0.4, true);
+
+    task.spawn(function()
+        if typeof(Time) == "Instance" then
+            Time.Destroying:Wait();
+        else
+            task.wait(Time or 5);
+        end
+
+        pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, 0, 0, YSize), 'Out', 'Quad', 0.4, true);
+
+        task.wait(0.4);
+
+        NotifyOuter:Destroy();
+    end);
+
+    return Data
 end;
 
-function Library:LeftNotify(Text, Time, SoundId)
+--[[function Library:LeftNotify(Text, Time, SoundId)
     Text = tostring(Text);
     local XSize, YSize = Library:GetTextBounds(Text, Library.Font, 14);
 
@@ -4817,7 +4945,7 @@ function Library:RightNotify(Text, Time, SoundId)
 
         NotifyOuter:Destroy();
     end);
-end;
+end;--]]
 
 function Library:CreateWindow(...)
     local Arguments = { ... }

--- a/Library.lua
+++ b/Library.lua
@@ -764,7 +764,7 @@ function Library:Unload()
         Library:SafeCallback(UnloadCallback)
     end
 
-    getgenv().LinoriaLib = nil
+    getgenv().Linoria = nil
     ScreenGui:Destroy()
 end
 

--- a/Library.lua
+++ b/Library.lua
@@ -777,6 +777,10 @@ Library:GiveSignal(ScreenGui.DescendantRemoving:Connect(function(Instance)
     end;
 end))
 
+local function Trim(Text: string)
+	return Text:match("^%s*(.-)%s*$")
+end
+
 local BaseAddons = {};
 
 do
@@ -2893,6 +2897,8 @@ do
             Finished = Info.Finished or false;
             Visible = if typeof(Info.Visible) == "boolean" then Info.Visible else true;
             Disabled = if typeof(Info.Disabled) == "boolean" then Info.Disabled else false;
+	    AllowEmpty = if typeof(Info.AllowEmpty) == "boolean" then Info.AllowEmpty else true;
+            EmptyReset = if typeof(Info.EmptyReset) == "string" then Info.EmptyReset else "---";
             Type = 'Input';
 
             Callback = Info.Callback or function(Value) end;
@@ -2976,7 +2982,7 @@ do
             PlaceholderColor3 = Color3.fromRGB(190, 190, 190);
             PlaceholderText = Info.Placeholder or '';
 
-            Text = Info.Default or '';
+            Text = Info.Default or (if Textbox.AllowEmpty == false then Textbox.EmptyReset else "---");
             TextColor3 = Library.FontColor;
             TextSize = 14;
             TextStrokeTransparency = 0;
@@ -3020,6 +3026,10 @@ do
         end;
 
         function Textbox:SetValue(Text)
+	    if not Textbox.AllowEmpty and Trim(Text) == "" then
+		Text = Textbox.EmptyReset;
+	    end
+
             if Info.MaxLength and #Text > Info.MaxLength then
                 Text = Text:sub(1, Info.MaxLength);
             end;

--- a/Library.lua
+++ b/Library.lua
@@ -1697,9 +1697,10 @@ do
 
                 local Key = KeyPicker.Value;
 
-                if Key == 'MB1' or Key == 'MB2' then
-                    return Key == 'MB1' and InputService:IsMouseButtonPressed(Enum.UserInputType.MouseButton1)
-                        or Key == 'MB2' and InputService:IsMouseButtonPressed(Enum.UserInputType.MouseButton2);
+                if Key == 'MB1' then
+                    return InputService:IsMouseButtonPressed(Enum.UserInputType.MouseButton1)
+                elseif Key == 'MB2' then
+                    return InputService:IsMouseButtonPressed(Enum.UserInputType.MouseButton2);
                 else
                     return InputService:IsKeyDown(Enum.KeyCode[KeyPicker.Value]) and not InputService:GetFocusedTextBox();
                 end;

--- a/Library.lua
+++ b/Library.lua
@@ -11,7 +11,7 @@ local LocalPlayer = Players.LocalPlayer;
 local Mouse = LocalPlayer:GetMouse();
 
 local DrawingLib = typeof(Drawing) == "table" and Drawing or { drawing_replaced = true };
-local ProtectGui = protectgui or (function() end);
+local ProtectGui = protectgui or (syn and syn.protect_gui) or (function() end);
 local GetHUI = gethui or (function() return CoreGui end);
 
 local ScreenGui = Instance.new('ScreenGui');

--- a/Library.lua
+++ b/Library.lua
@@ -4589,7 +4589,7 @@ function Library:Notify(...)
 
 	if typeof(Info) == "table" then
 		Data.Title = tostring(Info.Title)
-		Data.Description = (if Data.Title == "" then "" else "[" .. Data.Title .. "] ") .. tostring(Info.Description)
+		Data.Description = tostring(Info.Description)
 		Data.Time = Info.Time or 5
 		Data.SoundId = Info.SoundId
 	else
@@ -4599,8 +4599,7 @@ function Library:Notify(...)
 	end
     
     local Side = string.lower(Library.NotifySide);
-
-    local XSize, YSize = Library:GetTextBounds(Text, Library.Font, 14);
+    local XSize, YSize = Library:GetTextBounds(Data.Description, Library.Font, 14);
     YSize = YSize + 7
 
     local NotifyOuter = Library:Create('Frame', {
@@ -4656,7 +4655,7 @@ function Library:Notify(...)
         AnchorPoint = if Side == "left" then Vector2.new(0, 0) else Vector2.new(1, 0);
         Position = if Side == "left" then UDim2.new(0, 4, 0, 0) else UDim2.new(1, -4, 0, 0);
         Size = UDim2.new(1, -4, 1, 0);
-        Text = Text;
+        Text = (if Data.Title == "" then "" else "[" .. Data.Title .. "] ") .. tostring(Data.Description);
         TextXAlignment = if Side == "left" then Enum.TextXAlignment.Left else Enum.TextXAlignment.Right;
         TextSize = 14;
         ZIndex = 103;
@@ -4675,30 +4674,29 @@ function Library:Notify(...)
     });
 
     function Data:Resize()
-        XSize, YSize = Library:GetTextBounds(Data.Description, Library.Font, 14);
+        XSize, YSize = Library:GetTextBounds(NotifyLabel.Text, Library.Font, 14);
         YSize = YSize + 7
     
-		NotifyOuter.Size = UDim2.new(0, 0, 0, YSize);
+		pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, XSize * DPIScale + 8 + 4, 0, YSize), 'Out', 'Quad', 0.4, true);
 	end
 
 	function Data:ChangeTitle(NewText)
-		if Title then
-            NewText = tostring(NewText)
+        NewText = if NewText == nil then "" else tostring(NewText);
 
-            Data.Description = (if NewText == "" then "" else "[" .. NewText .. "] ") .. tostring(Info.Description)
-			NotifyLabel.Text = Data.Description;
+        Data.Title = NewText;
+        NotifyLabel.Text = (if Data.Title == "" then "" else "[" .. Data.Title .. "] ") .. tostring(Data.Description);
 
-			Data:Resize();
-		end
+        Data:Resize();
 	end
 
 	function Data:ChangeDescription(NewText)
-		if Desc then
-			Data.Description = tostring(NewText);
-			NotifyLabel.Text = Data.Description;
-            
-			Data:Resize();
-		end
+        if NewText == nil then return end
+        NewText = tostring(NewText);
+
+        Data.Description = NewText;
+        NotifyLabel.Text = (if Data.Title == "" then "" else "[" .. Data.Title .. "] ") .. tostring(Data.Description);
+
+        Data:Resize();
 	end
 
 	Data:Resize();
@@ -4707,9 +4705,9 @@ function Library:Notify(...)
         BackgroundColor3 = 'AccentColor';
     }, true);
 
-    if SoundId then
+    if Data.SoundId then
         Library:Create('Sound', {
-            SoundId = "rbxassetid://" .. tostring(SoundId):gsub("rbxassetid://", "");
+            SoundId = "rbxassetid://" .. tostring(Data.SoundId):gsub("rbxassetid://", "");
             Volume = 3;
             PlayOnRemove = true;
             Parent = game:GetService("SoundService");
@@ -4719,233 +4717,19 @@ function Library:Notify(...)
     pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, XSize * DPIScale + 8 + 4, 0, YSize), 'Out', 'Quad', 0.4, true);
 
     task.spawn(function()
-        if typeof(Time) == "Instance" then
-            Time.Destroying:Wait();
+        if typeof(Data.Time) == "Instance" then
+            Data.Time.Destroying:Wait();
         else
-            task.wait(Time or 5);
+            task.wait(Data.Time or 5);
         end
 
         pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, 0, 0, YSize), 'Out', 'Quad', 0.4, true);
-
         task.wait(0.4);
-
         NotifyOuter:Destroy();
     end);
 
     return Data
 end;
-
---[[function Library:LeftNotify(Text, Time, SoundId)
-    Text = tostring(Text);
-    local XSize, YSize = Library:GetTextBounds(Text, Library.Font, 14);
-
-    YSize = YSize + 7
-
-    local NotifyOuter = Library:Create('Frame', {
-        BorderColor3 = Color3.new(0, 0, 0);
-        Size = UDim2.new(0, 0, 0, YSize);
-        ClipsDescendants = true;
-        ZIndex = 100;
-        Parent = Library.LeftNotificationArea;
-    });
-
-    local NotifyInner = Library:Create('Frame', {
-        BackgroundColor3 = Library.MainColor;
-        BorderColor3 = Library.OutlineColor;
-        BorderMode = Enum.BorderMode.Inset;
-        Size = UDim2.new(1, 0, 1, 0);
-        ZIndex = 101;
-        Parent = NotifyOuter;
-    });
-
-    Library:AddToRegistry(NotifyInner, {
-        BackgroundColor3 = 'MainColor';
-        BorderColor3 = 'OutlineColor';
-    }, true);
-
-    local InnerFrame = Library:Create('Frame', {
-        BackgroundColor3 = Color3.new(1, 1, 1);
-        BorderSizePixel = 0;
-        Position = UDim2.new(0, 1, 0, 1);
-        Size = UDim2.new(1, -2, 1, -2);
-        ZIndex = 102;
-        Parent = NotifyInner;
-    });
-
-    local Gradient = Library:Create('UIGradient', {
-        Color = ColorSequence.new({
-            ColorSequenceKeypoint.new(0, Library:GetDarkerColor(Library.MainColor)),
-            ColorSequenceKeypoint.new(1, Library.MainColor),
-        });
-        Rotation = -90;
-        Parent = InnerFrame;
-    });
-
-    Library:AddToRegistry(Gradient, {
-        Color = function()
-            return ColorSequence.new({
-                ColorSequenceKeypoint.new(0, Library:GetDarkerColor(Library.MainColor)),
-                ColorSequenceKeypoint.new(1, Library.MainColor),
-            });
-        end
-    });
-
-    local NotifyLabel = Library:CreateLabel({
-        Position = UDim2.new(0, 4, 0, 0);
-        Size = UDim2.new(1, -4, 1, 0);
-        Text = Text;
-        TextXAlignment = Enum.TextXAlignment.Left;
-        TextSize = 14;
-        ZIndex = 103;
-        RichText = true;
-        Parent = InnerFrame;
-    });
-
-    local SideColor = Library:Create('Frame', {
-        BackgroundColor3 = Library.AccentColor;
-        BorderSizePixel = 0;
-        Position = UDim2.new(0, -1, 0, -1);
-        Size = UDim2.new(0, 3, 1, 2);
-        ZIndex = 104;
-        Parent = NotifyOuter;
-    });
-
-    Library:AddToRegistry(SideColor, {
-        BackgroundColor3 = 'AccentColor';
-    }, true);
-
-    if SoundId then
-        Library:Create('Sound', {
-            SoundId = "rbxassetid://" .. tostring(SoundId):gsub("rbxassetid://", "");
-            Volume = 3;
-            PlayOnRemove = true;
-            Parent = game:GetService("SoundService");
-        }):Destroy();
-    end
-
-    pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, XSize * DPIScale + 8 + 4, 0, YSize), 'Out', 'Quad', 0.4, true);
-
-    task.spawn(function()
-        if typeof(Time) == "Instance" then
-            Time.Destroying:Wait();
-        else
-            task.wait(Time or 5);
-        end
-
-        pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, 0, 0, YSize), 'Out', 'Quad', 0.4, true);
-
-        task.wait(0.4);
-
-        NotifyOuter:Destroy();
-    end);
-end;
-
-function Library:RightNotify(Text, Time, SoundId)
-    Text = tostring(Text);
-    local XSize, YSize = Library:GetTextBounds(Text, Library.Font, 14);
-
-    YSize = YSize + 7
-
-    local NotifyOuter = Library:Create('Frame', {
-        BorderColor3 = Color3.new(0, 0, 0);
-        Size = UDim2.new(0, 0, 0, YSize);
-        ClipsDescendants = true;
-        ZIndex = 100;
-        Parent = Library.RightNotificationArea;
-    });
-
-    local NotifyInner = Library:Create('Frame', {
-        BackgroundColor3 = Library.MainColor;
-        BorderColor3 = Library.OutlineColor;
-        BorderMode = Enum.BorderMode.Inset;
-        Size = UDim2.new(1, 0, 1, 0);
-        ZIndex = 101;
-        Parent = NotifyOuter;
-    });
-
-    Library:AddToRegistry(NotifyInner, {
-        BackgroundColor3 = 'MainColor';
-        BorderColor3 = 'OutlineColor';
-    }, true);
-
-    local InnerFrame = Library:Create('Frame', {
-        BackgroundColor3 = Color3.new(1, 1, 1);
-        BorderSizePixel = 0;
-        Position = UDim2.new(0, 1, 0, 1);
-        Size = UDim2.new(1, -2, 1, -2);
-        ZIndex = 102;
-        Parent = NotifyInner;
-    });
-
-    local Gradient = Library:Create('UIGradient', {
-        Color = ColorSequence.new({
-            ColorSequenceKeypoint.new(0, Library:GetDarkerColor(Library.MainColor)),
-            ColorSequenceKeypoint.new(1, Library.MainColor),
-        });
-        Rotation = -90;
-        Parent = InnerFrame;
-    });
-
-    Library:AddToRegistry(Gradient, {
-        Color = function()
-            return ColorSequence.new({
-                ColorSequenceKeypoint.new(0, Library:GetDarkerColor(Library.MainColor)),
-                ColorSequenceKeypoint.new(1, Library.MainColor),
-            });
-        end
-    });
-
-    local NotifyLabel = Library:CreateLabel({
-        AnchorPoint = Vector2.new(1, 0);
-        Position = UDim2.new(1, -4, 0, 0);
-        Size = UDim2.new(1, -4, 1, 0);
-        Text = Text;
-        TextXAlignment = Enum.TextXAlignment.Right;
-        TextSize = 14;
-        ZIndex = 103;
-        RichText = true;
-        Parent = InnerFrame;
-    });
-
-    local SideColor = Library:Create('Frame', {
-        AnchorPoint = Vector2.new(1, 0);
-        BackgroundColor3 = Library.AccentColor;
-        BorderSizePixel = 0;
-        Position = UDim2.new(1, -1, 0, -1);
-        Size = UDim2.new(0, 3, 1, 2);
-        ZIndex = 104;
-        Parent = NotifyOuter;
-    });
-
-    Library:AddToRegistry(SideColor, {
-        BackgroundColor3 = 'AccentColor';
-    }, true);
-
-    if SoundId then
-        Library:Create('Sound', {
-            SoundId = "rbxassetid://" .. tostring(SoundId):gsub("rbxassetid://", "");
-            Volume = 3;
-            PlayOnRemove = true;
-            Parent = game:GetService("SoundService");
-        }):Destroy();
-    end
-
-    pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, XSize * DPIScale + 8 + 4, 0, YSize), 'Out', 'Quad', 0.4, true);
-
-    task.spawn(function()
-        if typeof(Time) == "Instance" then
-            Time.Destroying:Wait();
-        else
-            task.wait(Time or 5);
-        end
-
-        pcall(NotifyOuter.TweenSize, NotifyOuter, UDim2.new(0, 0, 0, YSize), 'Out', 'Quad', 0.4, true);
-
-        task.wait(0.4);
-
-        NotifyOuter:Destroy();
-    end);
-end;--]]
 
 function Library:CreateWindow(...)
     local Arguments = { ... }

--- a/Library.lua
+++ b/Library.lua
@@ -2255,12 +2255,12 @@ do
         end;
 
         function Dropdown:AddValues(NewValues)
-            if typeof(Values) == "table" then
-				for _, val in pairs(Values) do
+            if typeof(NewValues) == "table" then
+				for _, val in pairs(NewValues) do
 					table.insert(Dropdown.Values, val);
 				end
-			elseif typeof(Values) == "string" then
-				table.insert(Dropdown.Values, val);
+			elseif typeof(NewValues) == "string" then
+				table.insert(Dropdown.Values, NewValues);
 			else
 				return;
 			end
@@ -2282,7 +2282,7 @@ do
 					table.insert(Dropdown.DisabledValues, val)
 				end
 			elseif typeof(DisabledValues) == "string" then
-				table.insert(Dropdown.DisabledValues, val)
+				table.insert(Dropdown.DisabledValues, DisabledValues)
 			else
 				return
 			end

--- a/Library.lua
+++ b/Library.lua
@@ -11,7 +11,7 @@ local LocalPlayer = Players.LocalPlayer;
 local Mouse = LocalPlayer:GetMouse();
 
 local DrawingLib = typeof(Drawing) == "table" and Drawing or { drawing_replaced = true };
-local ProtectGui = protectgui or (syn and syn.protect_gui) or (function() end);
+local ProtectGui = protectgui or (function() end);
 local GetHUI = gethui or (function() return CoreGui end);
 
 local ScreenGui = Instance.new('ScreenGui');

--- a/Library.lua
+++ b/Library.lua
@@ -5563,12 +5563,13 @@ function Library:CreateWindow(...)
             Outer.Visible = true;
 
             if DrawingLib.drawing_replaced ~= true then
-                local Cursor = DrawingLib.new("Triangle")
-                Cursor.Thickness = 1
+                local Cursor = DrawingLib.new("Square")
+                Cursor.Size = Vector2.new(8, 8)
                 Cursor.Filled = true
                 Cursor.Visible = Library.ShowCustomCursor
 
-                local CursorOutline = DrawingLib.new("Triangle")
+                local CursorOutline = DrawingLib.new("Square")
+                CursorOutline.Size = Vector2.new(8, 8)
                 CursorOutline.Thickness = 1
                 CursorOutline.Filled = false
                 CursorOutline.Color = Color3.new(0, 0, 0)
@@ -5581,13 +5582,9 @@ function Library:CreateWindow(...)
                     local mPos = InputService:GetMouseLocation()
                     local X, Y = mPos.X, mPos.Y
                     Cursor.Color = Library.AccentColor
-                    Cursor.PointA = Vector2.new(X, Y)
-                    Cursor.PointB = Vector2.new(X + 16, Y + 6)
-                    Cursor.PointC = Vector2.new(X + 6, Y + 16)
+                    Cursor.Position = Vector2.new(X - 4, Y - 4)
                     Cursor.Visible = Library.ShowCustomCursor
-                    CursorOutline.PointA = Cursor.PointA
-                    CursorOutline.PointB = Cursor.PointB
-                    CursorOutline.PointC = Cursor.PointC
+                    CursorOutline.Position = Cursor.Position
                     CursorOutline.Visible = Library.ShowCustomCursor
 
                     if not Toggled or (not ScreenGui or not ScreenGui.Parent) then

--- a/Library.lua
+++ b/Library.lua
@@ -4658,7 +4658,7 @@ function Library:Notify(...)
         AnchorPoint = if Side == "left" then Vector2.new(0, 0) else Vector2.new(1, 0);
         Position = if Side == "left" then UDim2.new(0, 4, 0, 0) else UDim2.new(1, -4, 0, 0);
         Size = UDim2.new(1, -4, 1, 0);
-        Text = (if Data.Title == "" then "" else "[" .. Data.Title .. "] ") .. tostring(Data.Description);
+        Text = (if Data.Title == nil then "" else "[" .. tostring(tostring(Data.Title)) .. "] ") .. tostring(Data.Description);
         TextXAlignment = if Side == "left" then Enum.TextXAlignment.Left else Enum.TextXAlignment.Right;
         TextSize = 14;
         ZIndex = 103;

--- a/Library.lua
+++ b/Library.lua
@@ -5566,13 +5566,12 @@ function Library:CreateWindow(...)
             Outer.Visible = true;
 
             if DrawingLib.drawing_replaced ~= true then
-                local Cursor = DrawingLib.new("Square")
-                Cursor.Size = Vector2.new(8, 8)
+                local Cursor = DrawingLib.new("Triangle")
+                Cursor.Thickness = 1
                 Cursor.Filled = true
                 Cursor.Visible = Library.ShowCustomCursor
 
-                local CursorOutline = DrawingLib.new("Square")
-                CursorOutline.Size = Vector2.new(8, 8)
+                local CursorOutline = DrawingLib.new("Triangle")
                 CursorOutline.Thickness = 1
                 CursorOutline.Filled = false
                 CursorOutline.Color = Color3.new(0, 0, 0)
@@ -5585,9 +5584,13 @@ function Library:CreateWindow(...)
                     local mPos = InputService:GetMouseLocation()
                     local X, Y = mPos.X, mPos.Y
                     Cursor.Color = Library.AccentColor
-                    Cursor.Position = Vector2.new(X - 4, Y - 4)
+                    Cursor.PointA = Vector2.new(X, Y)
+                    Cursor.PointB = Vector2.new(X + 16, Y + 6)
+                    Cursor.PointC = Vector2.new(X + 6, Y + 16)
                     Cursor.Visible = Library.ShowCustomCursor
-                    CursorOutline.Position = Cursor.Position
+                    CursorOutline.PointA = Cursor.PointA
+                    CursorOutline.PointB = Cursor.PointB
+                    CursorOutline.PointC = Cursor.PointC
                     CursorOutline.Visible = Library.ShowCustomCursor
 
                     if not Toggled or (not ScreenGui or not ScreenGui.Parent) then

--- a/Library.lua
+++ b/Library.lua
@@ -287,7 +287,7 @@ function Library:MakeDraggable(Instance, Cutoff, IsMainWindow)
                 if IsMainWindow == true and Library.CantDragForced == true then
                     return;
                 end;
-           
+
                 local ObjPos = Vector2.new(
                     Mouse.X - Instance.AbsolutePosition.X,
                     Mouse.Y - Instance.AbsolutePosition.Y
@@ -366,7 +366,7 @@ function Library:MakeDraggableUsingParent(Instance, Parent, Cutoff, IsMainWindow
                 if IsMainWindow == true and Library.CantDragForced == true then
                     return;
                 end;
-  
+
                 local ObjPos = Vector2.new(
                     Mouse.X - Parent.AbsolutePosition.X,
                     Mouse.Y - Parent.AbsolutePosition.Y
@@ -1655,7 +1655,7 @@ do
             local ShowToggle = Library.ShowToggleFrameInKeybinds and KeyPicker.Mode == 'Toggle';
 
             if KeybindsToggle.Loaded then
-		        KeybindsToggle:SetNormal(not ShowToggle)
+                KeybindsToggle:SetNormal(not ShowToggle)
 
                 KeybindsToggle:SetVisibility(true);
                 KeybindsToggle:SetText(string.format('[%s] %s (%s)', KeyPicker.Value, Info.Text, KeyPicker.Mode));
@@ -2511,21 +2511,21 @@ do
     function BaseGroupboxFuncs:AddLabel(...)
         local Data = {}
 
-    	if select(2, ...) ~= nil and typeof(select(2, ...)) == "table" then
+        if select(2, ...) ~= nil and typeof(select(2, ...)) == "table" then
             if select(1, ...) ~= nil then
                 assert(typeof(select(1, ...)) == "string", "Expected string for Idx, got " .. typeof(select(1, ...)))
             end
             
-    		local Params = select(2, ...)
+            local Params = select(2, ...)
 
-    		Data.Text = Params.Text or ""
-    		Data.DoesWrap = Params.DoesWrap or false
-    		Data.Idx = select(1, ...)
-    	else
-    		Data.Text = select(1, ...) or ""
-    		Data.DoesWrap = select(2, ...) or false
+            Data.Text = Params.Text or ""
+            Data.DoesWrap = Params.DoesWrap or false
+            Data.Idx = select(1, ...)
+        else
+            Data.Text = select(1, ...) or ""
+            Data.DoesWrap = select(2, ...) or false
             Data.Idx = select(3, ...) or nil
-    	end
+        end
 
         Data.OriginalText = Data.Text;
         
@@ -2900,7 +2900,7 @@ do
             Finished = Info.Finished or false;
             Visible = if typeof(Info.Visible) == "boolean" then Info.Visible else true;
             Disabled = if typeof(Info.Disabled) == "boolean" then Info.Disabled else false;
-	    AllowEmpty = if typeof(Info.AllowEmpty) == "boolean" then Info.AllowEmpty else true;
+            AllowEmpty = if typeof(Info.AllowEmpty) == "boolean" then Info.AllowEmpty else true;
             EmptyReset = if typeof(Info.EmptyReset) == "string" then Info.EmptyReset else "---";
             Type = 'Input';
 
@@ -3029,9 +3029,9 @@ do
         end;
 
         function Textbox:SetValue(Text)
-	    if not Textbox.AllowEmpty and Trim(Text) == "" then
-		Text = Textbox.EmptyReset;
-	    end
+            if not Textbox.AllowEmpty and Trim(Text) == "" then
+                Text = Textbox.EmptyReset;
+            end
 
             if Info.MaxLength and #Text > Info.MaxLength then
                 Text = Text:sub(1, Info.MaxLength);

--- a/Library.lua
+++ b/Library.lua
@@ -1253,7 +1253,7 @@ do
         function ColorPicker:OnChanged(Func)
             ColorPicker.Changed = Func;
             
-            Library:SafeCallback(Func, ColorPicker.Value);
+            Library:SafeCallback(Func, ColorPicker.Value, ColorPicker.Transparency);
         end;
 
         if ParentObj.Addons then


### PR DESCRIPTION
This enables cleaner code.

Example:
```lua
UI.Options["chamsFillColor"]:OnChanged(function(color, transparency)
	VisualHandler.chamsFillColor = color
	VisualHandler.chamsFillTransparency = transparency
end)
```
Where before you would have to do:
```lua
local chamsFillColor = UI.Options["chamsFillColor"]
chamsFillColor:OnChanged(function(color)
	VisualHandler.chamsFillColor = color
	VisualHandler.chamsFillTransparency = chamsFillColor.Transparency
end)
```