### PR TITLE
fix inverted ReturnInstanceInstead on player dropdowns

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -5870,8 +5870,8 @@ function Library:CreateWindow(...)
 end;
 
 local function OnPlayerChange()
-    local PlayerList, ExcludedPlayerList = GetPlayers(false, false), GetPlayers(true, false);
-    local StringPlayerList, StringExcludedPlayerList = GetPlayers(false, true), GetPlayers(true, true);
+    local PlayerList, ExcludedPlayerList = GetPlayers(false, true), GetPlayers(true, true);
+    local StringPlayerList, StringExcludedPlayerList = GetPlayers(false, false), GetPlayers(true, false);
 
     for _, Value in next, Options do
         if Value.SetValues and Value.Type == 'Dropdown' and Value.SpecialType == 'Player' then


### PR DESCRIPTION
The `ReturnInstanceInstead` property has inverted behavior for special player dropdowns.

![Code_06-07-32-032](https://github.com/user-attachments/assets/8951e515-fd26-4687-bbd3-c62454405c22)
![Code_06-19-05-874](https://github.com/user-attachments/assets/f8840642-695d-4ec0-bc46-2935f99ac9ce)
<sub>`playerusername` is a string, not an instance</sub>

This pr fixes that.